### PR TITLE
fix(build): Use remote MacosUseSDK dependency instead of local path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+.build
 # But DO track the specific executable
 !/.build/debug/mcp-server-macos-use
 /Packages

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "07957602bb99a5355c810187e66e6ce378a1057d",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "macosusesdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mediar-ai/MacosUseSDK.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "5d810b557dc73f8fb930767671b0cfcd989a23e7"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
-        "version" : "1.6.3"
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
       }
     },
     {
@@ -14,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "cfcead8121de466624a1357e02894616b0057805",
-        "version" : "0.7.1"
+        "revision" : "f1b50e6de22b5206068bb09851d585f560d893c4",
+        "version" : "0.10.1"
       }
     },
     {
@@ -23,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
-        "version" : "1.4.2"
+        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
+        "version" : "1.6.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.7.1"),
-        .package(path: "../MacosUseSDK")
+        .package(url: "https://github.com/mediar-ai/MacosUseSDK.git", branch: "main")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
## Summary

This PR fixes a dependency issue causing the build to fail.
The project required a local `../MacosUseSDK` directory to build successfully.

## Changes Made

- **Switch from local to remote dependency**: Replace `path: "../MacosUseSDK"` with `url: "https://github.com/mediar-ai/MacosUseSDK.git"` in Package.swift
- **Update Package.resolved**: Include latest dependency versions for all packages
- **Improve .gitignore**: Add `.build` pattern for better build artifact exclusion
- **Verify functionality**: Build tested and confirmed working with remote dependency

## Testing

- `swift build` completes successfully
- All existing functionality preserved
- No breaking changes to API or implementation

This resolves build failures due to missing local MacosUseSDK dependency.